### PR TITLE
Agregando página 404

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,25 @@
+---
+import Layout from "@layouts/Layout.astro";
+import Heading from "@components/heading/Heading.astro";
+import Text from "@components/text/Text.astro";
+import Button from "@components/button/Button.astro";
+import Link from "@components/link/Link.astro";
+---
+
+<Layout title="404 | Modo Guerra">
+  <section
+    class="min-h-dvh w-full flex flex-col gap-10 items-center justify-center md:gap-12"
+  >
+    <Heading
+      fontSize="large"
+      color="text-secondary"
+      className="text-center text-pretty"
+    >
+      ¡NOOOOOO MI COMPA!</Heading
+    >
+    <Text fontSize="large" className="text-center">
+      Esta página aún no se convierte en un Alfa
+    </Text>
+    <Link href="/"> <Button>Volver al Inicio</Button> </Link>
+  </section>
+</Layout>


### PR DESCRIPTION
Agregue un diseño inicial para la página 404 cuando no se encuentre una url
Antes:

<img width="1915" height="907" alt="image" src="https://github.com/user-attachments/assets/adf8e412-4f70-4937-ba7e-b8273f0abcb8" />


Ahora:

<img width="1900" height="906" alt="image" src="https://github.com/user-attachments/assets/82630113-6734-4fb6-8fbb-0aabb69cbbc5" />
